### PR TITLE
Child children no longer updates multiple times when props and state changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ launch.json
 # datasets
 /src/store/_archive
 /src/store/sims
-/src/assets/_archive
 
 # misc
 .DS_Store

--- a/src/components/Chart/Chart.js
+++ b/src/components/Chart/Chart.js
@@ -33,11 +33,8 @@ class Chart extends Component {
         
     }
 
-    componentDidUpdate(prevProps, prevState) {
-        // console.log(this.props.start, this.props.end)
-        // console.log('Chart componentDidUpdate')
-        // console.log(prevProps)
-        // console.log(this.props)
+    componentDidUpdate(prevProps) {
+
         if (prevProps.start !== this.props.start || 
             prevProps.end !== this.props.end ||
             prevProps.dataset !== this.props.dataset ||
@@ -198,98 +195,98 @@ class Chart extends Component {
             </rect>
             {this.state.severities.map( (severity, i) => {
             return (
-                    <g key={`chart-group-${severity}`}>
-                        { Object.entries(this.state.quantileObj[this.props.stat][severity]).map( ([key, value], j) => {
-                            // console.log(severity, 'barPos', key, this.state.xScale(key))
-                            // console.log(this.props.stat, i, j, severity, this.state.yScale(value.median))
-                            if (!(this.props.stat === 'incidI' && (severity === 'high' || severity === 'low'))) {
-                                return (
-                                    <Fragment key={`chart-fragment-${severity}-${key}`}>
-                                        <rect 
+                <g key={`chart-group-${severity}`}>
+                    { Object.entries(this.state.quantileObj[this.props.stat][severity]).map( ([key, value], j) => {
+                        // console.log(severity, 'barPos', key, this.state.xScale(key))
+                        // console.log(this.props.stat, i, j, severity, this.state.yScale(value.median))
+                        if (!(this.props.stat === 'incidI' && (severity === 'high' || severity === 'low'))) {
+                            return (
+                                <Fragment key={`chart-fragment-${severity}-${key}`}>
+                                    <rect 
+                                        d={value}
+                                        key={`bar-${severity}-${key}`}
+                                        className={`bar-${severity}-${key}`}
+                                        width={barWidth}
+                                        height={this.state.yScale(0) - this.state.yScale(value.median)}
+                                        x={(margin.left * 2) + (i * (barWidth + barMargin)) + this.state.xScale(key)}
+                                        y={this.state.yScale(value.median)}
+                                        fill={scenarioColors[j]}
+                                        stroke={this.state.hoveredRect.severity === severity &&
+                                            this.state.hoveredRect.scenario === key ? blue: scenarioColors[j]}
+                                        strokeWidth={4}
+                                        style={{ pointerEvents: 'none' }}
+                                    >
+                                    </rect>
+                                    <line
+                                        key={`vertline-${severity}-${key}`}
+                                        className={`vertline-${severity}-${key}`}
+                                        x1={(barWidth/2 + (margin.left * 2) + (i * (barWidth + barMargin)) + this.state.xScale(key))}
+                                        y1={this.state.yScale(value.ninetyith)}
+                                        x2={(barWidth/2 + (margin.left * 2) + (i * (barWidth + barMargin)) + this.state.xScale(key))}
+                                        y2={this.state.yScale(value.tenth)}
+                                        stroke={gray}
+                                        strokeWidth={1}
+                                        style={{ pointerEvents: 'none' }}
+                                    >
+                                    </line>
+                                    <line
+                                        key={`topline-${severity}-${key}`}
+                                        className={`topline-${severity}-${key}`}
+                                        x1={(whiskerMargin + (margin.left * 2) + (i * (barWidth + barMargin)) + this.state.xScale(key))}
+                                        y1={this.state.yScale(value.ninetyith)}
+                                        x2={(barWidth - whiskerMargin + (margin.left * 2) + (i * (barWidth + barMargin)) + this.state.xScale(key))}
+                                        y2={this.state.yScale(value.ninetyith)}
+                                        stroke={gray}
+                                        strokeWidth={1}
+                                        style={{ pointerEvents: 'none' }}
+                                    >
+                                    </line>
+                                    <line
+                                        key={`bottomline-${severity}-${key}`}
+                                        className={`bottomline-${severity}-${key}`}
+                                        x1={(whiskerMargin + (margin.left * 2) + (i * (barWidth + barMargin)) + this.state.xScale(key))}
+                                        y1={this.state.yScale(value.tenth)}
+                                        x2={(barWidth - whiskerMargin + (margin.left * 2) + (i * (barWidth + barMargin)) + this.state.xScale(key))}
+                                        y2={this.state.yScale(value.tenth)}
+                                        stroke={gray}
+                                        strokeWidth={1}
+                                        style={{ pointerEvents: 'none' }}
+                                    >
+                                    </line>
+                                    <Tooltip
+                                        key={`tooltip-chart-${i}-${j}`}
+                                        title={this.state.tooltipText}
+                                        visible={this.state.hoveredRect.severity === severity &&
+                                                this.state.hoveredRect.scenario === key ? true : false}
+                                        data-html="true"
+                                    >
+                                        {/* debug red rect highlight */}
+                                        <rect
                                             d={value}
-                                            key={`bar-${severity}-${key}`}
-                                            className={`bar-${severity}-${key}`}
+                                            key={`bar-${severity}-${key}-hover`}
+                                            className={'bars-hover'}
                                             width={barWidth}
-                                            height={this.state.yScale(0) - this.state.yScale(value.median)}
+                                            // height={this.state.yScale(0) - this.state.yScale(value.median)}
+                                            height={this.state.yScale(value.median) / (this.props.height - margin.bottom) > 0.9 ? 20 : this.state.yScale(0) - this.state.yScale(value.median)}
                                             x={(margin.left * 2) + (i * (barWidth + barMargin)) + this.state.xScale(key)}
-                                            y={this.state.yScale(value.median)}
-                                            fill={scenarioColors[j]}
-                                            stroke={this.state.hoveredRect.severity === severity &&
-                                                this.state.hoveredRect.scenario === key ? blue: scenarioColors[j]}
+                                            y={ this.state.yScale(value.median) / (this.props.height - margin.bottom) > 0.9 ? this.props.height - margin.bottom - 20 : this.state.yScale(value.median)}
+                                            fill={'red'}
+                                            fillOpacity={0}
+                                            stroke={'red'}
+                                            strokeOpacity={0}
                                             strokeWidth={4}
-                                            style={{ pointerEvents: 'none' }}
+                                            style={{ cursor: 'pointer'}}
+                                            onMouseEnter={(e) => this.handleHighlightEnter(e, severity, key, j)}
+                                            onMouseLeave={this.handleHighlightLeave}
                                         >
                                         </rect>
-                                        <line
-                                            key={`vertline-${severity}-${key}`}
-                                            className={`vertline-${severity}-${key}`}
-                                            x1={(barWidth/2 + (margin.left * 2) + (i * (barWidth + barMargin)) + this.state.xScale(key))}
-                                            y1={this.state.yScale(value.ninetyith)}
-                                            x2={(barWidth/2 + (margin.left * 2) + (i * (barWidth + barMargin)) + this.state.xScale(key))}
-                                            y2={this.state.yScale(value.tenth)}
-                                            stroke={gray}
-                                            strokeWidth={1}
-                                            style={{ pointerEvents: 'none' }}
-                                        >
-                                        </line>
-                                        <line
-                                            key={`topline-${severity}-${key}`}
-                                            className={`topline-${severity}-${key}`}
-                                            x1={(whiskerMargin + (margin.left * 2) + (i * (barWidth + barMargin)) + this.state.xScale(key))}
-                                            y1={this.state.yScale(value.ninetyith)}
-                                            x2={(barWidth - whiskerMargin + (margin.left * 2) + (i * (barWidth + barMargin)) + this.state.xScale(key))}
-                                            y2={this.state.yScale(value.ninetyith)}
-                                            stroke={gray}
-                                            strokeWidth={1}
-                                            style={{ pointerEvents: 'none' }}
-                                        >
-                                        </line>
-                                        <line
-                                            key={`bottomline-${severity}-${key}`}
-                                            className={`bottomline-${severity}-${key}`}
-                                            x1={(whiskerMargin + (margin.left * 2) + (i * (barWidth + barMargin)) + this.state.xScale(key))}
-                                            y1={this.state.yScale(value.tenth)}
-                                            x2={(barWidth - whiskerMargin + (margin.left * 2) + (i * (barWidth + barMargin)) + this.state.xScale(key))}
-                                            y2={this.state.yScale(value.tenth)}
-                                            stroke={gray}
-                                            strokeWidth={1}
-                                            style={{ pointerEvents: 'none' }}
-                                        >
-                                        </line>
-                                        <Tooltip
-                                            key={`tooltip-chart-${i}-${j}`}
-                                            title={this.state.tooltipText}
-                                            visible={this.state.hoveredRect.severity === severity &&
-                                                    this.state.hoveredRect.scenario === key ? true : false}
-                                            data-html="true"
-                                        >
-                                            {/* debug red rect highlight */}
-                                            <rect
-                                                d={value}
-                                                key={`bar-${severity}-${key}-hover`}
-                                                className={'bars-hover'}
-                                                width={barWidth}
-                                                // height={this.state.yScale(0) - this.state.yScale(value.median)}
-                                                height={this.state.yScale(value.median) / (this.props.height - margin.bottom) > 0.9 ? 20 : this.state.yScale(0) - this.state.yScale(value.median)}
-                                                x={(margin.left * 2) + (i * (barWidth + barMargin)) + this.state.xScale(key)}
-                                                y={ this.state.yScale(value.median) / (this.props.height - margin.bottom) > 0.9 ? this.props.height - margin.bottom - 20 : this.state.yScale(value.median)}
-                                                fill={'red'}
-                                                fillOpacity={0}
-                                                stroke={'red'}
-                                                strokeOpacity={0}
-                                                strokeWidth={4}
-                                                style={{ cursor: 'pointer'}}
-                                                onMouseEnter={(e) => this.handleHighlightEnter(e, severity, key, j)}
-                                                onMouseLeave={this.handleHighlightLeave}
-                                            >
-                                            </rect>
-                                        </Tooltip>
-                                    </Fragment>
-                                )
-                            }
-                        })
-                    }
-                    </g>
+                                    </Tooltip>
+                                </Fragment>
+                            )
+                        }
+                    })
+                }
+                </g>
                 )
             })}
             </Fragment>

--- a/src/components/Chart/MainChart.js
+++ b/src/components/Chart/MainChart.js
@@ -16,7 +16,7 @@ class MainChart extends Component {
     constructor(props) {
         super(props);
         this.state = {
-            dataLoaded: false,
+            datasetChart: {},
             dates: [],
             SCENARIOS: [],
             scenarioList: [],
@@ -25,18 +25,16 @@ class MainChart extends Component {
             start: new Date(),
             end: new Date(),
             scale: 'power',
+            dataLoaded: false
         };
     };
 
     componentDidMount() {
-        // console.log('MainChart componentDidMount')
         const { dataset } = this.props;
         this.initializeChart(dataset)
     };
 
     componentDidUpdate(prevProp) {
-        // console.log('MainChart componentDidUpdate dataset', this.props.dataset)
-
         const { dataset } = this.props;
 
         if (dataset !== prevProp.dataset) {
@@ -45,12 +43,9 @@ class MainChart extends Component {
     };
 
     initializeChart(dataset) {
-        // instantiate scenarios 
+        // instantiate scenarios, initial default indicators
         const SCENARIOS = buildScenarios(dataset);  
         const scenarioList = SCENARIOS.map(s => s.name);
-        // console.log('MainChart scenarioList', scenarioList)
-
-        // instantiate default 2 indicator stats
         const statList = STATS.slice(0,2)
 
         // instantiate start and end date (past 2 weeks) for summary stats
@@ -58,16 +53,17 @@ class MainChart extends Component {
         const start = new Date(); 
         start.setDate(start.getDate() - 14); 
 
+        // dataset needs to be set to state at the same time as other props
+        // otherwise, children updates will occur at different times
         this.setState({
+            datasetChart: dataset, 
             dates,
             SCENARIOS,
             scenarioList,
             statList,
             start,
         }, () => {
-            this.setState({
-                dataLoaded: true
-            });
+            this.setState({dataLoaded: true});
         })
     }
 
@@ -126,7 +122,7 @@ class MainChart extends Component {
                                 geoid={this.props.geoid}
                                 width={this.props.width}
                                 height={this.props.height} 
-                                dataset={this.props.dataset}
+                                dataset={this.state.datasetChart}
                                 scenarios={this.state.scenarioList}
                                 stats={this.state.statList}
                                 firstDate={this.state.dates[0]}

--- a/src/components/Graph/Graph.js
+++ b/src/components/Graph/Graph.js
@@ -39,7 +39,6 @@ class Graph extends Component {
     
     componentDidMount() {
         // console.log('ComponentDidMount', this.props.keyVal)
-        // console.log(this.state.series)
         this.drawSimPaths(this.state.series, this.state.dates);
         if (this.state.confBounds && this.state.confBounds.length > 0) this.drawConfBounds(this.state.confBounds, this.state.areaGenerator, this.state.dates);
     }
@@ -50,7 +49,6 @@ class Graph extends Component {
         if (this.props.showConfBounds !== prevProps.showConfBounds && this.props.confBounds) {
             // console.log('showConfBounds is', this.props.showConfBounds)
             if (this.props.confBounds) {
-                console.log(this.props.confBounds)
                 const { confBounds, dates} = this.props;
                 const { areaGenerator } = prevState;
                 this.updateConfBounds(confBounds, areaGenerator, dates)

--- a/src/components/MainContainer.js
+++ b/src/components/MainContainer.js
@@ -8,7 +8,7 @@ import MainChart from './Chart/MainChart';
 import MainMap from './Map/MainMap';
 import Methodology from './Methodology';
 
-const dataset = require('../store/geo36005.json');
+const dataset = require('../store/geo06085.json');
 
 
 class MainContainer extends Component {
@@ -17,7 +17,7 @@ class MainContainer extends Component {
         this.state = {
             dataset: {},
             dataLoaded: false, 
-            geoid: '36005', 
+            geoid: '06085', 
             graphW: 0,
             graphH: 0,
             mapContainerW: 0,
@@ -26,9 +26,7 @@ class MainContainer extends Component {
     };
 
     componentDidMount() {
-        // console.log('componentDidMount')
-        console.log('dataset', dataset)
-        
+        // console.log('MainContainer componentDidMount')
         window.addEventListener('resize', this.updateGraphDimensions);
         window.addEventListener('resize', this.updateMapContainerDimensions);
 
@@ -63,6 +61,7 @@ class MainContainer extends Component {
     };
     
     handleUpload = (dataset, geoid) => {
+        console.log('Main handleUpload', geoid, dataset)
         this.setState({dataset, geoid})
     };
 

--- a/src/components/Map/MainMap.js
+++ b/src/components/Map/MainMap.js
@@ -15,6 +15,7 @@ class MainMap extends Component {
     constructor(props) {
         super(props);
         this.state = {
+            datasetMap: {},
             dates: [],
             SCENARIOS: [],
             scenario: '',         
@@ -54,6 +55,7 @@ class MainMap extends Component {
             .findIndex(date => formatDate(date) === formatDate(new Date()));
 
         this.setState({
+            datasetMap: dataset, 
             dates,
             SCENARIOS,
             scenario,
@@ -61,9 +63,7 @@ class MainMap extends Component {
             statsForCounty,
             currentDateIndex,
         }, () => {
-            this.setState({
-                dataLoaded: true
-            });
+            this.setState({dataLoaded: true});
         })
     }
 
@@ -95,7 +95,7 @@ class MainMap extends Component {
                             <div className="map-container">
                                 <MapContainer
                                     geoid={this.props.geoid}
-                                    dataset={this.props.dataset}
+                                    dataset={this.state.datasetMap}
                                     width={this.props.width}
                                     height={this.props.height}
                                     scenario={this.state.scenario}

--- a/src/components/Methodology.js
+++ b/src/components/Methodology.js
@@ -1,12 +1,13 @@
 import React, { Component } from 'react';
 import { Layout, Col } from 'antd';
+import { styles } from '../utils/constants';
 
 class Methodology extends Component {
   
     render() {
         const { Content } = Layout;
         return (
-            <Content id="methods" style={{ background: '#fefefe', padding: '50px 0', height: '80vh' }}>
+            <Content id="methods" style={styles.ContainerWhite}>
                 <Col className="gutter-row container" span={16}>
                     <div className="content-section">
                         <div className="content-header">Methodology</div>

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -17,7 +17,8 @@ export const mapHighColors = ['#3885fa', '#008769', '#e6550d', '#de2d26']
 export const styles = {
     ContainerWhite: {
         background: '#fefefe',
-        padding: '5rem 0'
+        padding: '5rem 0',
+        minHeight: '80vh'
     },
     ContainerGray: {
         padding: '5rem 0'

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,6 +1,7 @@
 import { extent } from 'd3-array';
 import { timeDay } from 'd3-time';
 import { timeFormat } from 'd3-time-format';
+const formatDate = timeFormat('%Y-%m-%d');
 ///////////////// UTILS ///////////////////
 
 // TODO: most likely remove this function
@@ -36,6 +37,27 @@ export function buildScenarios(dataset) {
     scenarioArray.push(obj);
   }
   return scenarioArray;
+}
+
+export function returnSimsOverThreshold(series, statThreshold, dates, dateThreshold) {
+  // Marks which simulations in a series are above threshold given stat and date
+
+  const dateIndex = dates.findIndex(
+      date => formatDate(date) === formatDate(dateThreshold)
+      );
+  let simsOver = 0;
+  Object.values(series).forEach((sim) => {
+      let simOver = false;
+      for (let i = 0; i < dateIndex; i++) {
+          if (sim.vals[i] > statThreshold){
+              simsOver = simsOver + 1;
+              simOver = true;
+              break;
+          }
+      }
+      simOver ? sim.over = true : sim.over = false
+  })
+  return simsOver;
 }
 
 export function addCommas(x) {


### PR DESCRIPTION
This PR addresses an issue that came up after the refactor (lifting MainContainer up and creating separate Graph, Chart, and Map children components).

Because `dataset` was sent as a prop to `MainChart` and other variables such as `stats`, `start`, `scenarios`, etc were from state, Chart componentDidUpdate was triggering multiple times. This means, `dataset` would trigger an update before `scenarios` had a chance to populate, resulting in undefined TypeError. Now, dataset is set to state at the same time as other props are in `initializeChart` function of `MainChart`; otherwise, children updates will occur at different times.

Closes #40 