### PR TITLE
User can select any start date, min threshold set to 0

### DIFF
--- a/src/components/Chart/DatePicker.js
+++ b/src/components/Chart/DatePicker.js
@@ -20,12 +20,9 @@ class Chart extends Component {
     }
 
     disabledDate = (dateMoment) => {
+        // prevent user from selecting beyond modeled date range
         const date = dateMoment._d;
-        return (
-            date < this.props.firstDate || 
-            date > this.props.lastDate ||
-            date.getDay() > 0
-            );
+        return date < this.props.firstDate || date > this.props.lastDate;
     }
 
     handleOpen = (datePickerOpen) => {
@@ -43,7 +40,7 @@ class Chart extends Component {
                 <RangePicker
                     disabledDate={this.disabledDate} 
                     style={styles.Selector}
-                    renderExtraFooter={() => "Select a summary period in weekly increments"}
+                    // renderExtraFooter={() => "Select a summary period in weekly increments"}
                     onChange={this.handleChange}
                     onOpenChange={this.handleOpen}
                 />

--- a/src/components/Filters/Sliders.js
+++ b/src/components/Filters/Sliders.js
@@ -68,7 +68,7 @@ class Sliders extends Component {
                 <input
                     id="statThreshold"
                     type="range"
-                    min={seriesMin.toString()}
+                    min="0"
                     max={seriesMax.toString()}
                     value={statThreshold.toString()}
                     step={100}
@@ -79,9 +79,7 @@ class Sliders extends Component {
                     onMouseUp={this.handleStatMouseEvent}>
                 </input> 
                 <div className="slider-label-row slider-label" style={styles.Selector}>
-                    <p className="filter-label callout" style={styles.SliderLabel}>
-                        {addCommas(seriesMin)}
-                    </p>
+                    <p className="filter-label callout" style={styles.SliderLabel}>0</p>
                     <p className="filter-label slider-max callout" style={styles.SliderLabel}>
                         {addCommas(seriesMax)}
                     </p>

--- a/src/components/Graph/MainGraph.js
+++ b/src/components/Graph/MainGraph.js
@@ -82,7 +82,7 @@ class MainGraph extends Component {
             const idxMax = timeDay.count(this.state.dates[0], this.state.dateRange[1]);
             const filteredDates = Array.from(this.state.allTimeDates.slice(idxMin, idxMax));
             const dateThresholdIdx = Math.ceil(filteredDates.length / 2)
-            const dateThreshold = filteredDates[dateThresholdIdx]
+            const dateThreshold = filteredDates[dateThresholdIdx];
             let statThreshold = 0
             let sliderMin = 100000000000
             let sliderMax = 0
@@ -103,7 +103,8 @@ class MainGraph extends Component {
                 const [seriesMin, seriesMax] = getRange(seriesPeaks);
                 if (seriesMin < sliderMin) sliderMin = seriesMin
                 if (seriesMax > sliderMax) sliderMax = seriesMax
-                if (i === 0) statThreshold = Math.ceil(seriesMax / 1.2);
+                // default smart value for statThreshold calculation
+                if (i === 0) statThreshold = seriesMin;
 
                 const simsOver = returnSimsOverThreshold(
                     newSeries, statThreshold, this.state.allTimeDates, dateThreshold);
@@ -410,7 +411,7 @@ class MainGraph extends Component {
                             stat={this.state.stat}
                             dates={this.state.dates}
                             seriesMax={this.state.seriesMax}
-                            seriesMin={this.state.seriesMin}
+                            // seriesMin={this.state.seriesMin}
                             statThreshold={this.state.statThreshold}
                             dateThreshold={this.state.dateThreshold}
                             dateThresholdIdx={this.state.dateThresholdIdx}

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -67,7 +67,7 @@ export function addCommas(x) {
 }
 
 export function getRange(seriesPeaks) {
-  // return range [min, max] of all sims given a series
+  // return range [min, max] of all peaks of sims given a series
   const seriesPeakExtent = extent(seriesPeaks)
 
   // take out rounding until display


### PR DESCRIPTION
User can now select any start or end date in Chart's date range picker.
Graph stat slider minimum threshold is now set to 0, while default smart value is set to the minimum peak of simulations in view.

Closes #34 #28 