### PR TITLE
Chart Severity Labels

### DIFF
--- a/src/components/Chart/Chart.js
+++ b/src/components/Chart/Chart.js
@@ -217,6 +217,13 @@ class Chart extends Component {
                                         style={{ pointerEvents: 'none' }}
                                     >
                                     </rect>
+                                    <text 
+                                        className='tick'
+                                        opacity={0.65}
+                                        textAnchor='center'
+                                        x={(margin.left * 2) + (i * ((barWidth) + barMargin)) + this.state.xScale(key) - 7 + (i*3.5) + (barWidth * 0.5) }
+                                        y={this.props.height - 8}
+                                    >{severity}</text>
                                     <line
                                         key={`vertline-${severity}-${key}`}
                                         className={`vertline-${severity}-${key}`}

--- a/src/components/Chart/Chart.js
+++ b/src/components/Chart/Chart.js
@@ -220,7 +220,7 @@ class Chart extends Component {
                                     <text 
                                         className='tick'
                                         opacity={0.65}
-                                        textAnchor='center'
+                                        textAnchor='middle'
                                         x={(margin.left * 2) + (i * ((barWidth) + barMargin)) + this.state.xScale(key) - 7 + (i*3.5) + (barWidth * 0.5) }
                                         y={this.props.height - 8}
                                     >{severity}</text>

--- a/src/components/Chart/Chart.js
+++ b/src/components/Chart/Chart.js
@@ -222,7 +222,7 @@ class Chart extends Component {
                                         opacity={0.65}
                                         textAnchor='middle'
                                         x={(margin.left * 2) + (i * ((barWidth) + barMargin)) + this.state.xScale(key) - 7 + (i*3.5) + (barWidth * 0.5) }
-                                        y={this.props.height - 8}
+                                        y={this.props.height - 22}
                                     >{severity}</text>
                                     <line
                                         key={`vertline-${severity}-${key}`}

--- a/src/components/Graph/Axis.js
+++ b/src/components/Graph/Axis.js
@@ -55,7 +55,15 @@ class Axis extends Component {
       
 
       if (this.axisRef.current) {
-          select(this.axisRef.current).call(this.axis).call(g => g.select(".domain").remove());
+          
+          if (this.props.view === 'chart') {
+            select(this.axisRef.current).call(this.axis)
+            .call(g => g.select(".domain").remove())
+            .call(g => g.selectAll("text").attr("dy", "2em"));
+          } else {
+            select(this.axisRef.current).call(this.axis)
+            .call(g => g.select(".domain").remove());
+          }
       }
     }
   }

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -6,7 +6,7 @@ export const margin = {
     yAxis: 80, 
     top: 10, 
     right: 10, 
-    bottom: 30, 
+    bottom: 40, 
     left: 10, 
     chartTop: 15 
 };


### PR DESCRIPTION
Adding the severity labels to the Chart Summary view. Does not address text wrapping for Scenario label, so ideally works with short Scenario names. Consider a character limit for this.