### PR TITLE
Sim selection over/under inconsistency

### DIFF
--- a/src/components/Graph/MainGraph.js
+++ b/src/components/Graph/MainGraph.js
@@ -122,13 +122,16 @@ class MainGraph extends Component {
             const idxMax = timeDay.count(dates[0], dateRange[1]);
             const [indicatorThreshold, seriesMin, seriesMax] = getindicatorThreshold(
                 [firstScenario], [series], idxMin, idxMax);
-            const simsOver = flagSims(
-                series, indicatorThreshold, dates, dateThreshold)        
+            
+            // flagSims uses filtered dates and series so that threshold slider
+            // shows over/under based on selected date range
             const newSelectedDates = Array.from(dates).slice(idxMin, idxMax);
-            const filteredSeries = filterByDate(series, idxMin, idxMax)
-
+            const filteredSeries = filterByDate(series, idxMin, idxMax);
+            const simsOver = flagSims(
+                filteredSeries, indicatorThreshold, newSelectedDates, dateThreshold);       
+            
             const confBoundsList = getConfBounds(
-                dataset, [firstScenario], severityList, firstIndicator, dates, idxMin, idxMax)
+                dataset, [firstScenario], severityList, firstIndicator, dates, idxMin, idxMax);
 
             const actualList = getActuals(actuals, firstIndicator, [firstScenario]);
 
@@ -189,7 +192,7 @@ class MainGraph extends Component {
             scenarioList, reducedSeriesList, idxMin, idxMax);
 
         const [flaggedSeriesList, simsOverList] = flagSimsOverThreshold(
-            scenarioList, reducedSeriesList, dates, idxMin, idxMax, 
+            scenarioList, reducedSeriesList, newSelectedDates, idxMin, idxMax, 
             indicatorThreshold, dateThreshold)
 
         const percExceedenceList = getExceedences(
@@ -325,6 +328,7 @@ class MainGraph extends Component {
             const simsOver = flagSims(seriesList[i], thresh, selectedDates, dateThreshold);
             const percExceedence = simsOver / seriesList[i].length;
             percExceedenceList.push(percExceedence);
+            console.log(seriesList)
         }
         this.setState({
             seriesList,
@@ -334,6 +338,7 @@ class MainGraph extends Component {
             animateTransition: false
         });
     };
+
 
     handleDateSliderChange = (thresh) => {
         const { indicatorThreshold, selectedDates, dates } = this.state;

--- a/src/components/Graph/MainGraph.js
+++ b/src/components/Graph/MainGraph.js
@@ -328,7 +328,6 @@ class MainGraph extends Component {
             const simsOver = flagSims(seriesList[i], thresh, selectedDates, dateThreshold);
             const percExceedence = simsOver / seriesList[i].length;
             percExceedenceList.push(percExceedence);
-            console.log(seriesList)
         }
         this.setState({
             seriesList,

--- a/src/components/Search/SearchBar.tsx
+++ b/src/components/Search/SearchBar.tsx
@@ -66,7 +66,7 @@ class SearchBar extends Component<Props, State> {
         return (
             <Select
                 showSearch
-                placeholder="Search for your county"
+                placeholder="Search for your state or county"
                 optionFilterProp="children"
                 style={this.props.style}
                 size={"large"}

--- a/src/utils/threshold.js
+++ b/src/utils/threshold.js
@@ -99,6 +99,7 @@ export function getindicatorThreshold(scenarioList, seriesList, idxMin, idxMax) 
   export function getRange(seriesPeaks) {
     // return range [min, max] of all peaks of sims given a series
     const seriesPeakExtent = extent(seriesPeaks)
+    if (typeof seriesPeakExtent[1] == 'undefined') return [0, 0];
     let roundingVal;
     if (seriesPeakExtent[1].toString().length < 2) {
       roundingVal = 1

--- a/src/utils/threshold.js
+++ b/src/utils/threshold.js
@@ -38,18 +38,20 @@ export function getindicatorThreshold(scenarioList, seriesList, idxMin, idxMax) 
     return [indicatorThresholds[0], sliderMin, sliderMax]; 
   }
   
-  export function flagSimsOverThreshold(scenarioList, seriesList, allTimeDates, 
+  export function flagSimsOverThreshold(scenarioList, seriesList, selectedDates, 
     idxMin, idxMax, indicatorThreshold, dateThreshold) {
     // return series with sims flagged above or below thresholds
     const filteredSeriesList = [];
     const simsOverList = [];
   
     for (let i = 0; i < scenarioList.length; i++) {
-      // mutate seriesList to flag which sims are above/below thresholds
-      const simsOver = flagSims(seriesList[i], indicatorThreshold, allTimeDates, dateThreshold);
       // filter mutated seriesList by dates
       const filteredSeries = filterByDate(seriesList[i], idxMin, idxMax)
-  
+      // mutate filtered seriesList to flag which sims are above/below thresholds
+      // flagSims uses filtered dates and filtered series (what is shown on graph)
+      // so that threshold sliders correctly display which sims are over/under threshold
+      const simsOver = flagSims(filteredSeries, indicatorThreshold, selectedDates, dateThreshold);
+        
       filteredSeriesList.push(filteredSeries)
       simsOverList.push(simsOver)
     }
@@ -60,7 +62,6 @@ export function getindicatorThreshold(scenarioList, seriesList, idxMin, idxMax) 
     // MUTATION: flags which sims in a series are above indicator and date threshold 
     const dateIndex = dates.findIndex(
       date => formatDate(date) === formatDate(dateThreshold));
-
     let simsOver = 0;
     Object.values(series).forEach((sim) => {
       let simOver = false;


### PR DESCRIPTION
This PR fixes a bug we noticed where the brush handler calling the MainGraph update treated the sims over/under coloring differently from the slider handlers. This also enables the enhancement of coloring the sims based on the selected date range and series current visible in the Graph.

Should close #160 